### PR TITLE
COBJCON-6: Fix the exception thrown when there is an error while storing

### DIFF
--- a/src/main/java/org/mule/extension/objectstore/internal/ObjectStoreOperations.java
+++ b/src/main/java/org/mule/extension/objectstore/internal/ObjectStoreOperations.java
@@ -115,7 +115,7 @@ public class ObjectStoreOperations {
                                                                                          createStaticMessage("ObjectStore already contains an object for key '"
                                                                                              + key + "'")));
         } else {
-          os.remove(key);
+          removeTask(os, key);
           os.store(key, value);
         }
       } catch (ObjectStoreException e) {
@@ -203,21 +203,7 @@ public class ObjectStoreOperations {
                      @Optional @ParameterDsl(allowInlineDefinition = false) @Expression(NOT_SUPPORTED) ObjectStore objectStore) {
     validateKey(key);
 
-    withLockedKey(objectStore, key, os -> {
-      try {
-        os.remove(key);
-      } catch (ObjectDoesNotExistException e) {
-        throw new ModuleException(KEY_NOT_FOUND, new ObjectDoesNotExistException(createStaticMessage(format(
-                                                                                                            "ObjectStore doesn't contain any value for key '%s'",
-                                                                                                            key))));
-      } catch (ObjectStoreException e) {
-        if (e.getMessage().contains(RATE_LIMIT_EXCEEDED_PATTERN)) {
-          throw new ModuleException(STORE_NOT_AVAILABLE, new ObjectStoreException(createStaticMessage("Rate Limit exceeded"), e));
-        }
-        throw e;
-      }
-      return null;
-    });
+    withLockedKey(objectStore, key, os -> removeTask(os, key));
   }
 
   /**
@@ -298,6 +284,21 @@ public class ObjectStoreOperations {
 
       return all;
     });
+  }
+
+  private Serializable removeTask(ObjectStore<Serializable> os, String key) throws ObjectStoreException {
+    try {
+      return os.remove(key);
+    } catch (ObjectDoesNotExistException e) {
+      throw new ModuleException(KEY_NOT_FOUND, new ObjectDoesNotExistException(createStaticMessage(format(
+              "ObjectStore doesn't contain any value for key '%s'",
+              key))));
+    } catch (ObjectStoreException e) {
+      if (e.getMessage().contains(RATE_LIMIT_EXCEEDED_PATTERN)) {
+        throw new ModuleException(STORE_NOT_AVAILABLE, new ObjectStoreException(createStaticMessage("Rate Limit exceeded"), e));
+      }
+      throw e;
+    }
   }
 
   private boolean validateValue(TypedValue<Serializable> value, boolean failOnNullValue) {

--- a/src/main/java/org/mule/extension/objectstore/internal/ObjectStoreOperations.java
+++ b/src/main/java/org/mule/extension/objectstore/internal/ObjectStoreOperations.java
@@ -291,8 +291,8 @@ public class ObjectStoreOperations {
       return os.remove(key);
     } catch (ObjectDoesNotExistException e) {
       throw new ModuleException(KEY_NOT_FOUND, new ObjectDoesNotExistException(createStaticMessage(format(
-              "ObjectStore doesn't contain any value for key '%s'",
-              key))));
+                                                                                                          "ObjectStore doesn't contain any value for key '%s'",
+                                                                                                          key))));
     } catch (ObjectStoreException e) {
       if (e.getMessage().contains(RATE_LIMIT_EXCEEDED_PATTERN)) {
         throw new ModuleException(STORE_NOT_AVAILABLE, new ObjectStoreException(createStaticMessage("Rate Limit exceeded"), e));

--- a/src/test/java/org/mule/extension/objectstore/internal/ObjectStoreOperationsTestCase.java
+++ b/src/test/java/org/mule/extension/objectstore/internal/ObjectStoreOperationsTestCase.java
@@ -11,10 +11,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.lock.LockFactory;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.store.ObjectAlreadyExistsException;
@@ -24,14 +22,12 @@ import org.mule.runtime.api.store.ObjectStoreException;
 import org.mule.runtime.api.store.ObjectStoreManager;
 import org.mule.runtime.extension.api.exception.ModuleException;
 
-import java.io.Serializable;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,7 +54,7 @@ public class ObjectStoreOperationsTestCase {
     ObjectStore objectStore = mock(ObjectStore.class);
     when(objectStore.toString()).thenReturn("objectStoreStringRepresentation");
     when(runtimeObjectStoreManager.getDefaultPartition()).thenReturn(objectStore);
-    when(objectStore.retrieve(Matchers.any())).thenThrow(new ObjectDoesNotExistException());
+    when(objectStore.retrieve(any())).thenThrow(new ObjectDoesNotExistException());
 
     expectedException.expect(ModuleException.class);
     expectedException.expectMessage(containsString("ObjectStore 'objectStoreStringRepresentation'"));
@@ -77,7 +73,7 @@ public class ObjectStoreOperationsTestCase {
     when(runtimeObjectStoreManager.getDefaultPartition()).thenReturn(objectStore);
     Exception e =
         new Exception("Unable to check existence of object with key test in store APP_osdemo__defaultPersistentObjectStore, status code was 429, response was null");
-    when(objectStore.retrieve(Matchers.any())).thenThrow(new ObjectStoreException(e));
+    when(objectStore.retrieve(any())).thenThrow(new ObjectStoreException(e));
 
     expectedException.expect(ModuleException.class);
     expectedException.expectMessage(containsString("Rate Limit"));
@@ -93,9 +89,9 @@ public class ObjectStoreOperationsTestCase {
     when(objectStore.toString()).thenReturn("objectStoreStringRepresentation");
     when(runtimeObjectStoreManager.getDefaultPartition()).thenReturn(objectStore);
     Exception exceptionAlreadyExists = new Exception("ObjectStore already contains entry for key 123");
-    doThrow(new ObjectAlreadyExistsException(exceptionAlreadyExists)).when(objectStore).store(Matchers.any(), Matchers.any());
+    doThrow(new ObjectAlreadyExistsException(exceptionAlreadyExists)).when(objectStore).store(any(), any());
     Exception exceptionDoesNotExists = new Exception("ObjectStore doesn't contain any value for key '123'");
-    doThrow(new ObjectDoesNotExistException(exceptionDoesNotExists)).when(objectStore).remove(Matchers.any());
+    doThrow(new ObjectDoesNotExistException(exceptionDoesNotExists)).when(objectStore).remove(any());
 
     expectedException.expect(ModuleException.class);
     expectedException.expectMessage(containsString("ObjectStore doesn't contain any value for key '123'"));


### PR DESCRIPTION
#### Description:
Under load, the OS connector throws MULE:UNKNOWN error when trying to store data. The expectation is to have an OS: error as opposed to MULE: error code so that it can be handled better in a flow.

#### Cause:
When the method store tries to save to an existing key, the exception thrown is caught and then the method remove and store are called but then the exceptions aren't converted to ModuleExceptions.

#### Solution:
Call a remove private method with the proper try and catch instead of calling directly to object-store remove.