### PR TITLE
[DO NOT MERGE] PoC of parameter to use a local Object Store

### DIFF
--- a/src/main/java/org/mule/extension/objectstore/api/ExtensionObjectStore.java
+++ b/src/main/java/org/mule/extension/objectstore/api/ExtensionObjectStore.java
@@ -9,10 +9,13 @@ package org.mule.extension.objectstore.api;
 import static java.lang.String.format;
 import static org.mule.runtime.api.connection.ConnectionValidationResult.success;
 import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
+import static org.mule.runtime.core.api.config.MuleProperties.LOCAL_OBJECT_STORE_MANAGER;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STORE_MANAGER;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 import static org.slf4j.LoggerFactory.getLogger;
+
+import org.mule.extension.objectstore.internal.MuleObjectStoreManagerProvider;
 import org.mule.extension.objectstore.internal.ObjectStoreConnector;
 import org.mule.extension.objectstore.internal.ObjectStoreRegistry;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -78,6 +81,10 @@ public abstract class ExtensionObjectStore implements ObjectStore<Serializable>,
   @Inject
   @Named(OBJECT_STORE_MANAGER)
   private ObjectStoreManager runtimeObjectStoreManager;
+
+  @Inject
+  @Named(LOCAL_OBJECT_STORE_MANAGER)
+  private ObjectStoreManager runtimeLocalObjectStoreManager;
 
   /**
    * Whether the store is persistent or transient.
@@ -149,6 +156,14 @@ public abstract class ExtensionObjectStore implements ObjectStore<Serializable>,
   @Expression(NOT_SUPPORTED)
   @ParameterDsl(allowInlineDefinition = false)
   protected ObjectStoreConnector config;
+
+  /**
+   * When running in cluster mode, this indicates that the {@link ObjectStore} is local to the node instead of being distributed.
+   */
+  @Parameter
+  @Optional(defaultValue = "false")
+  @Expression(NOT_SUPPORTED)
+  private boolean local;
 
   private transient ConnectionProvider<ObjectStoreManager> storeManagerProvider;
   private transient ObjectStoreManager objectStoreManager;
@@ -342,7 +357,17 @@ public abstract class ExtensionObjectStore implements ObjectStore<Serializable>,
                                      e);
     }
 
-    return configurationProvider.getConnectionProvider().orElseGet(FallbackObjectStoreManagerProvider::new);
+    ConnectionProvider<ObjectStoreManager> connectionProvider = configurationProvider.getConnectionProvider()
+        .orElseGet(FallbackObjectStoreManagerProvider::new);
+    if (connectionProvider instanceof MuleObjectStoreManagerProvider) {
+      // If the default is configured we need to switch between local and non-local based on the configuration.
+      if (local) {
+        // The fallback does exactly that.
+        return new FallbackObjectStoreManagerProvider();
+      }
+    }
+
+    return connectionProvider;
   }
 
   // TODO: this can be removed after MULE-15209 is fixed.
@@ -361,7 +386,7 @@ public abstract class ExtensionObjectStore implements ObjectStore<Serializable>,
 
     @Override
     public ObjectStoreManager connect() throws ConnectionException {
-      return runtimeObjectStoreManager;
+      return local ? runtimeLocalObjectStoreManager : runtimeObjectStoreManager;
     }
 
     @Override
@@ -433,5 +458,9 @@ public abstract class ExtensionObjectStore implements ObjectStore<Serializable>,
 
   public void setConfig(ObjectStoreConnector config) {
     this.config = config;
+  }
+
+  public boolean isLocal() {
+    return local;
   }
 }

--- a/src/main/java/org/mule/extension/objectstore/internal/lock/LocalLockFactory.java
+++ b/src/main/java/org/mule/extension/objectstore/internal/lock/LocalLockFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.extension.objectstore.internal.lock;
+
+import org.mule.runtime.api.lock.LockFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+// Ideally we should be able to consume the LOCAL_OBJECT_LOCK_FACTORY however, that one also has the LockProvider overridden with
+// the one for clustering mode.
+// This implementation does not perform reclamation of unused entries. It is not suitable for applications that can potentially
+// use an unbounded number of distinct lock IDs.
+public class LocalLockFactory implements LockFactory {
+
+  private final Map<String, Lock> locks = new ConcurrentHashMap<>();
+
+  @Override
+  public Lock createLock(String lockId) {
+    return locks.computeIfAbsent(lockId, key -> new ReentrantLock(true));
+  }
+}


### PR DESCRIPTION
This is an alternative of #181. In this case it is presented as an additional feature over the official Object Store Connector, while in the other one it was presented as a separate (cloned) extension with different GAV and packages.